### PR TITLE
More cache in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
             target
+            tmp/*/xfcc_parser_ruby/*/target
+            ~/.cargo/git
+            ~/.cargo/registry
           key: test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-ruby-${{ matrix.ruby }}-git-${{ github.sha }}
           restore-keys: |
             test-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-ruby-${{ matrix.ruby }}-
@@ -84,10 +85,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
             target
+            tmp/*/xfcc_parser_ruby/*/target
             vendor/bundle
+            ~/.cargo/git
+            ~/.cargo/registry
           key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-ruby-${{ matrix.ruby }}-git-${{ github.sha }}
           restore-keys: |
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-ruby-${{ matrix.ruby }}-


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`5250ff5`](https://github.com/Frederick888/xfcc_parser_ruby/pull/2/commits/5250ff5daf89f054b50ff58500fa2e1c904112e9) ci: Cache Rust artefacts in tmp/



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
