### PR TITLE
build: Unset platform versions in binary gems

### DIFF
--- a/xfcc_parser_ruby.gemspec
+++ b/xfcc_parser_ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Frederick888/xfcc_parser_ruby/"
   spec.required_ruby_version = [">= 2.6.0", "< 3.2.0"]
   spec.required_rubygems_version = ">= 3.3.11"
-  spec.platform = Gem::Platform.local if binary_gem
+  spec.platform = Gem::Platform.local.tap { |p| p.version = nil } if binary_gem
 
   # spec.metadata['allowed_push_host'] = "TODO: Set to your gem server 'https://example.com'"
 


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`50651d1`](https://github.com/Frederick888/xfcc_parser_ruby/pull/4/commits/50651d1dd060b61bd31759a61b33e7ebcc31b1fe) build: Unset platform versions in binary gems

Affects macOS at the moment. The gem is usually compatible with recent
versions of macOS so we don't have to pin it down.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
